### PR TITLE
[BLU-3466] Improve Faucet

### DIFF
--- a/contracts/Faucet.sol
+++ b/contracts/Faucet.sol
@@ -12,7 +12,6 @@ contract Faucet is Ownable {
     address public contractRegistry;
     address public bctAddress;
     address public nctAddress;
-    mapping(address => uint256) private tokenBalances;
     mapping(address => uint256) private lastWithdrawalTimes;
     event Deposited(address erc20Addr, uint256 amount);
     event Withdrawn(address account, address erc20Addr, uint256 amount);
@@ -34,12 +33,6 @@ contract Faucet is Ownable {
         address _address
     ) public virtual onlyOwner {
         contractRegistry = _address;
-    }
-
-    function getTokenBalance(
-        address _erc20Address
-    ) public view returns (uint256) {
-        return tokenBalances[_erc20Address];
     }
 
     // @description checks if token to be deposited is eligible for this pool
@@ -75,9 +68,6 @@ contract Faucet is Ownable {
             _amount
         );
 
-        // add amount of said token to balance sheet of this contract
-        tokenBalances[_erc20Address] += _amount;
-
         // emit an event for good measure
         emit Deposited(_erc20Address, _amount);
     }
@@ -111,12 +101,9 @@ contract Faucet is Ownable {
 
         // require that the person didn't request more than the contract has
         require(
-            tokenBalances[_erc20Address] >= _amount,
+            IERC20(_erc20Address).balanceOf(address(this)) >= _amount,
             "Cannot withdraw more than is stored in contract"
         );
-
-        // subtract amount of said token from the balance sheet of this contract
-        tokenBalances[_erc20Address] -= _amount;
 
         // use TCO contract to do a safe transfer from this contract to the user
         IERC20(_erc20Address).safeTransfer(msg.sender, _amount);

--- a/contracts/Faucet.sol
+++ b/contracts/Faucet.sol
@@ -102,6 +102,8 @@ contract Faucet is Ownable {
         require(!checkIfWithdrawalTimeout(), "Cannot withdraw that often");
         lastWithdrawalTimes[msg.sender] = block.timestamp;
 
+        require(_amount <= 5 ether, "Cannot withdraw more than 5 tokens");
+
         IERC20(_erc20Address).safeTransfer(msg.sender, _amount);
 
         emit Withdrawn(msg.sender, _erc20Address, _amount);

--- a/contracts/Faucet.sol
+++ b/contracts/Faucet.sol
@@ -112,12 +112,6 @@ contract Faucet is Ownable {
         require(!checkIfWithdrawalTimeout(), "Cannot withdraw that often");
         lastWithdrawalTimes[msg.sender] = block.timestamp;
 
-        // require that the person didn't request more than the contract has
-        require(
-            IERC20(_erc20Address).balanceOf(address(this)) >= _amount,
-            "Cannot withdraw more than is stored in contract"
-        );
-
         // use TCO contract to do a safe transfer from this contract to the user
         IERC20(_erc20Address).safeTransfer(msg.sender, _amount);
 

--- a/contracts/Faucet.sol
+++ b/contracts/Faucet.sol
@@ -124,4 +124,14 @@ contract Faucet is Ownable {
         // emit an event for good measure
         emit Withdrawn(msg.sender, _erc20Address, _amount);
     }
+
+    /// @notice function that is only callable by owner and can withdraw as many tokens from this contract as they want
+    /// @param _erc20Address address of the token to be withdrawn
+    /// @param _amount amount of tokens to be withdrawn
+    function ownerWithdraw(
+        address _erc20Address,
+        uint256 _amount
+    ) public onlyOwner {
+        IERC20(_erc20Address).safeTransfer(msg.sender, _amount);
+    }
 }

--- a/contracts/Faucet.sol
+++ b/contracts/Faucet.sol
@@ -35,6 +35,19 @@ contract Faucet is Ownable {
         contractRegistry = _address;
     }
 
+    /// @notice A function to get the Faucet's balances of multiple tokens at once
+    /// @param _erc20Addresses An array of ERC20 contract addresses
+    /// @return An array of balances
+    function getTokenBalances(
+        address[] memory _erc20Addresses
+    ) public view returns (uint256[] memory) {
+        uint256[] memory balances = new uint256[](_erc20Addresses.length);
+        for (uint256 i = 0; i < _erc20Addresses.length; i++) {
+            balances[i] = IERC20(_erc20Addresses[i]).balanceOf(address(this));
+        }
+        return balances;
+    }
+
     // @description checks if token to be deposited is eligible for this pool
     // @param _erc20Address address to be checked
     function checkTokenEligibility(

--- a/test/index.ts
+++ b/test/index.ts
@@ -70,9 +70,6 @@ describe("TCO2Faucet", function () {
           ethers.utils.parseEther(amount)
         );
         expect(myTcoBalanceAfter).to.eql(expectedTcoBalance);
-
-        const faucetTcoBalance = await faucet.getTokenBalance(tco2Address);
-        expect(ethers.utils.formatEther(faucetTcoBalance)).to.eql("1.0");
       });
     }
   });
@@ -104,9 +101,6 @@ describe("TCO2Faucet", function () {
           ethers.utils.parseEther(amountToWithdraw)
         );
         expect(myTcoBalanceAfter).to.eql(expectedTcoBalance);
-
-        const faucetTcoBalance = await faucet.getTokenBalance(tco2Address);
-        expect(ethers.utils.formatEther(faucetTcoBalance)).to.eql("0.0");
       });
 
       it(`Should revert withdrawing ${tco2Name} with a timeout error`, async () => {


### PR DESCRIPTION
# Why?

As documented in the [issue](https://linear.app/toucan/issue/BLU-3466/improve-faucet) and initially discussed in [the EPIC](https://linear.app/toucan/issue/BLU-2824/epic-add-celo-support-in-tco2-faucet), the Faucet could use some improvements.

# What?

- remove `tokenBalances` because of data duplication (instead we'll use `IERC20.balanceOf` from now on)
- add helper function `getTokenBalances` to fetch Faucet's balances for multiple tokens in one call (will help on frontend)
- add 'god-mode' withdrawal function that `Owner` can use when migrating to new `Faucet` versions
- other minor improvements